### PR TITLE
Metakeys issue

### DIFF
--- a/src/event_binder.ts
+++ b/src/event_binder.ts
@@ -27,10 +27,12 @@ export class TypeGenieEventBinder {
         this.eventBinder = new BrowserEventBinder(this.stateManager.getScope())
 
         // Add keyboard events
+
         this.eventBinder.addKeyDownBind(KeyEnum.TAB, [], function (key: string, keyCode: number) {return true}, this.onAccept)
         this.eventBinder.addKeyDownBind(KeyEnum.TAB, [ModifierKeys.Shift], function (key: string, keyCode: number) {return true}, this.onPartialAccept)
         this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [], function (key: string, keyCode: number) {return true}, this.onAccept)
         this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [ModifierKeys.Shift], function (key: string, keyCode: number) {return true}, this.onPartialAccept)
+
         this.eventBinder.addKeyDownBind(DEFAULT, [], function (key: string, keyCode: number) {
             let completion = that.stateManager.editorState.completion
 
@@ -41,13 +43,24 @@ export class TypeGenieEventBinder {
                 return false
             }
         }, this.onTypingKeystroke)
-        this.eventBinder.addKeyUpBind(DEFAULT, [], function (){return false}, this.onQueryChange)
+
+        // TODO Check: First approach, addKeyUpBind for DEFAULT with ctrl as modifier, preventing further event propagation ---> This does not work as I expected (DEFAULT does not work with Modifiers?)
+        // this.eventBinder.addKeyUpBind(DEFAULT,[ModifierKeys.Control], function (key:string, keyCode: number){return true}, ()=>{console.log('Triggered keyUp with control')})
+
+        // New implementation, with preventHandleTrigger callback
+        this.eventBinder.addKeyUpBind(DEFAULT, [], function (key: string, keyCode: number){return false}, this.onQueryChange, function (e: KeyboardEvent) {
+            // Dont let callback run if modifier key is pressed on keyup
+            if(e.ctrlKey)
+                return true;
+        })
 
         // Add javascript events other than keyboard events.
         this.eventBinder.addEventHandler("click", this.onRemoveCompletion)
         this.eventBinder.addEventHandler("focusin", this.onRemoveCompletion)
         this.eventBinder.addEventHandler("focusout", this.onRemoveCompletion)
     }
+
+
 
     async onRemoveCompletion(key: string, keyCode: number) {
         let editorState = this.stateManager.editorState

--- a/src/event_binder.ts
+++ b/src/event_binder.ts
@@ -31,11 +31,12 @@ export class TypeGenieEventBinder {
         this.eventBinder.addKeyDownBind(KeyEnum.TAB, [], function (key: string, keyCode: number) {return true}, this.onAccept)
         this.eventBinder.addKeyDownBind(KeyEnum.TAB, [ModifierKeys.Shift], (key: string, keyCode: number) => true, this.onPartialAccept)
         this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [],
-            (key: string, keyCode: number) => window.getSelection().anchorOffset < window.getSelection().anchorNode.textContent.length ? false : true
-
+            (key: string, keyCode: number) => {
+                return that.stateManager.editorState.completion.length > 0 ? true : false
+            }
          , this.onAccept)
         this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [ModifierKeys.Shift],
-            (key: string, keyCode: number) => window.getSelection().anchorOffset < window.getSelection().anchorNode.textContent.length ? false : true
+            (key: string, keyCode: number) => false
             , this.onPartialAccept)
 
         this.eventBinder.addKeyDownBind(DEFAULT, [], function (key: string, keyCode: number) {

--- a/src/event_binder.ts
+++ b/src/event_binder.ts
@@ -29,9 +29,14 @@ export class TypeGenieEventBinder {
         // Add keyboard events
 
         this.eventBinder.addKeyDownBind(KeyEnum.TAB, [], function (key: string, keyCode: number) {return true}, this.onAccept)
-        this.eventBinder.addKeyDownBind(KeyEnum.TAB, [ModifierKeys.Shift], function (key: string, keyCode: number) {return true}, this.onPartialAccept)
-        this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [], function (key: string, keyCode: number) {return true}, this.onAccept)
-        this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [ModifierKeys.Shift], function (key: string, keyCode: number) {return true}, this.onPartialAccept)
+        this.eventBinder.addKeyDownBind(KeyEnum.TAB, [ModifierKeys.Shift], (key: string, keyCode: number) => true, this.onPartialAccept)
+        this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [],
+            (key: string, keyCode: number) => window.getSelection().anchorOffset < window.getSelection().anchorNode.textContent.length ? false : true
+
+         , this.onAccept)
+        this.eventBinder.addKeyDownBind(KeyEnum.RIGHT_ARROW, [ModifierKeys.Shift],
+            (key: string, keyCode: number) => window.getSelection().anchorOffset < window.getSelection().anchorNode.textContent.length ? false : true
+            , this.onPartialAccept)
 
         this.eventBinder.addKeyDownBind(DEFAULT, [], function (key: string, keyCode: number) {
             let completion = that.stateManager.editorState.completion

--- a/src/state_managers/froala.ts
+++ b/src/state_managers/froala.ts
@@ -61,9 +61,14 @@ export default class FroalaStateManager extends StateManager {
         }
     }
 
+
+
     setCompletion(completion: string) {
         this.removeCompletion()
         if(completion) {
+            // Experimental feature to collapse selection to the end of last range https://developer.mozilla.org/en-US/docs/Web/API/Selection/collapseToEnd
+            // Has some browser compatibility limitations but seems to be well supported by Chrome/Firefox
+            window.getSelection().collapseToEnd();
             let { anchorNode, anchorOffset } = window.getSelection()
             this.froalaEditor.html.insert(`<span style="color: rgba(0, 0, 0, 0.5)" class="${this.completionClass}">${completion}</span>`, false)
             this.setCaret(anchorNode, anchorOffset)


### PR DESCRIPTION
Solved some issues related to text editor interaction experience:

- Prevent crtl + default keystrokes from requesting completion

- Prevent selected text from being erased by showCompletion()

- Fix right arrow behavior when navigating through existing text (move right behavior was being suppressed)
